### PR TITLE
Arreglo de import socks en el módulo httplib2

### DIFF
--- a/pyafipws.py
+++ b/pyafipws.py
@@ -21,7 +21,7 @@ import sys
 import wsfe, wsbfe, wsfex, wsctg, wdigdepfiel
 from php import SimpleXMLElement, SoapFault, SoapClient, parse_proxy
 import traceback
-import socks
+from httplib2 import socks
 import warnings
 
 warnings.warn("Este modulo es obsoleto (mantenido por compatibilidad).\n"


### PR DESCRIPTION
Solución al problema de importación de socks:

Traceback (most recent call last):
  File "/usr/lib/python2.7/unittest/loader.py", line 252, in _find_tests
    module = self._get_module_from_name(name)
  File "/usr/lib/python2.7/unittest/loader.py", line 230, in _get_module_from_name
    __import__(name)
  File "/home/m4tuu/proyectos/freelance/fe/dfe/dfe/core/tests.py", line 16, in <module>
    from pyafipws.wsfev1 import WSFEv1
  File "/home/m4tuu/.virtualenvs/dfe/src/pyafipws/pyafipws.py", line 24, in <module>
    import socks
ImportError: No module named socks
