### PR TITLE
FIX get NCM and other errors handling

### DIFF
--- a/wsbfev1.py
+++ b/wsbfev1.py
@@ -77,8 +77,8 @@ class WSBFEv1(BaseWS):
             errores = [ret['BFEErr']]
             for error in errores:
                 self.Errores.append("%s: %s" % (
-                    error['ErrCode'],
-                    error['ErrMsg'],
+                    error.get('ErrCode', ''),
+                    error.get('ErrMsg', ''),
                     ))
             self.ErrCode = ' '.join([str(error['ErrCode']) for error in errores])
             self.ErrMsg = '\n'.join(self.Errores)


### PR DESCRIPTION
Mariano, algunas veces se devuelve un error pero sin error msg, al menos me pasa cuando pedis los codigos de producto NCM y da ok, Por eso uso el .get para obtener el resultado del diccionario cosa de que si no existe devuelva string vacia.