### PR TITLE
Corregir comparación de versiones, agregar ignore files para PyCharm 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# Pycharm
+.idea*

--- a/utils.py
+++ b/utils.py
@@ -38,6 +38,7 @@ from Cookie import SimpleCookie
 from ConfigParser import SafeConfigParser
 
 from pysimplesoap.client import SimpleXMLElement, SoapClient, SoapFault, parse_proxy, set_http_wrapper
+from pkg_resources import parse_version
 
 try:
     import json
@@ -433,9 +434,9 @@ class WebClient:
     def __init__(self, location, enctype="multipart/form-data", trace=False,
                        cacert=None, timeout=30):
         kwargs = {}
-        if httplib2.__version__ >= '0.3.0':
+        if parse_version(httplib2.__version__) >= parse_version('0.3.0'):
                 kwargs['timeout'] = timeout
-        if httplib2.__version__ >= '0.7.0':
+        if parse_version(httplib2.__version__) >= parse_version('0.7.0'):
                 kwargs['disable_ssl_certificate_validation'] = cacert is None
                 kwargs['ca_certs'] = cacert
         self.http = httplib2.Http(**kwargs)


### PR DESCRIPTION
Hice este pull request para corregir la comparación de versiones (que estaba hecha en base a strings) en utils.py.
En mi caso usando httplib2 version 0.11.3 y la comparación existente, al ser strings, falla con 0.3.0 y también con 0.7.0, por lo tanto no setea correctamente los kwargs.
Llegué a eso traceando el problema de SSL: CERTIFICATE_VERIFY_FAILED al usar iibb.py desde odoo 8.
Esta corrección solucionó el problema para mi.