### PR TITLE
Corrección al importar pythoncom en plataformas != Windows

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -883,8 +883,11 @@ def get_install_dir():
 
     if hasattr(sys, "frozen"):
         # we are running as py2exe-packed executable
-        import pythoncom
-        pythoncom.frozen = 1
+        try:
+            import pythoncom
+            pythoncom.frozen = 1
+        except ModuleNotFoundError:
+            pass
         sys.argv[0] = sys.executable
 
     return os.path.dirname(os.path.abspath(basepath))


### PR DESCRIPTION
La mayoría de imports de `pythocom` a lo largo del código se dan dentro del argumento `--register`, por lo cual se pueden considerar "conscientes"

El problema es que en el caso empaquetar la aplicación para macOS (pasaría lo mismo en Linux) da problemas, porque **no esta** corriendo en **Windows**, y mucho menos siendo empaquetada con **py2exe**

