### PR TITLE
Fix encoding por ajustes en PySimpleSOAP

### DIFF
--- a/iibb.py
+++ b/iibb.py
@@ -100,7 +100,7 @@ class IIBB:
             self.xml.fechaHasta = fecha_hasta
             self.xml.contribuyentes.contribuyente.cuitContribuyente = cuit_contribuyente
 
-            xml = self.xml.as_xml()
+            xml = self.xml.as_xml().encode('utf8')
             self.CodigoHash = md5(xml).hexdigest()
             nombre = "DFEServicioConsulta_%s.xml" % self.CodigoHash
 

--- a/wsaa.py
+++ b/wsaa.py
@@ -83,7 +83,7 @@ def create_tra(service=SERVICE, ttl=2400):
     tra.header.add_child('generationTime', str(date('c', date('U') - ttl)))
     tra.header.add_child('expirationTime', str(date('c', date('U') + ttl)))
     tra.add_child('service', service)
-    return tra.as_xml()
+    return tra.as_xml().encode('utf-8')
 
 
 def sign_tra(tra, cert=CERT, privatekey=PRIVATEKEY, passphrase=""):


### PR DESCRIPTION
Al corregir el código de PySimpleSOAP para que los tests pasen, aparecieron algunos bugs en PyAfipWs derivados del pase de **str/unicode** a **bytes/str**

Entonces `SimpleXMLElement.as_xml()` devuelve `str` como era esperado según los tests existentes, y se transforma a `bytes` en `IIBB` para usar con `hashlib.md5` y en `WSAA` con `M2Crypto.BIO.MemoryBuffer`

@lukio te meto a vos en la conversación para que estes al tanto.