### PR TITLE
Algunos fixes relacionados a importaciones incorrectas de módulos

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -114,8 +114,9 @@ try:
 
         httplib2._build_ssl_context = _build_ssl_context_new
 
-except:
-    print("para soporte de WebClient debe instalar httplib2")
+except ModuleNotFoundError as mnfe:
+    if "httplib2" in str(mnfe):
+        print("para soporte de WebClient debe instalar httplib2")
 
 
 DEBUG = False

--- a/utils.py
+++ b/utils.py
@@ -1131,9 +1131,11 @@ def get_install_dir():
 
     if hasattr(sys, "frozen"):
         # we are running as py2exe-packed executable
-        import pythoncom
-
-        pythoncom.frozen = 1
+        try:
+            import pythoncom
+            pythoncom.frozen = 1
+        except ModuleNotFoundError:
+            pass
         sys.argv[0] = sys.executable
 
     return os.path.dirname(os.path.abspath(basepath))

--- a/utils.py
+++ b/utils.py
@@ -114,7 +114,7 @@ try:
 
         httplib2._build_ssl_context = _build_ssl_context_new
 
-except ModuleNotFoundError as mnfe:
+except ImportError as mnfe:
     if "httplib2" in str(mnfe):
         print("para soporte de WebClient debe instalar httplib2")
 
@@ -1135,7 +1135,7 @@ def get_install_dir():
         try:
             import pythoncom
             pythoncom.frozen = 1
-        except ModuleNotFoundError:
+        except ImportError:
             pass
         sys.argv[0] = sys.executable
 


### PR DESCRIPTION
Hola, este PR contiene 2 fixes de errores de importación detectados en macOS, qué es el sistema donde se está haciendo deploy.

El primero (e83616c) es un fix que yo ya había publicado hace un tiempo atrás sobre la rama `py3k` y que vuelvo a incorporar a esta rama ya que el estado actual de la misma me permite abandonar `py3k`. El PR por el cual se integraron originalmente estos cambios a `py3k` es el #77 

El segundo (bf37d5c) es un fix para una salida en consola incorrecta, dado que el except es demasiado general y confunde la supuesta falta de `httplib2` con la efectiva falta del paquete `distro` que al momento no esta disponible para macOS y Windows

Agradecería que se puedan integrar estos cambios para eliminar algunos hardcodes que hubo que hacer para prevenir estos problemas