### PR TITLE
Only run release on original repository, not forks

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -156,6 +156,7 @@ jobs:
         run: |
           cat dist-64/.env >> $GITHUB_ENV
       - uses: "marvinpinto/action-automatic-releases@latest"
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: ${{ (github.ref_name != 'main') && 'beta' || 'latest' }}


### PR DESCRIPTION
This avoids errors with dependabot PR:
```
Run marvinpinto/action-automatic-releases@latest
Initializing the Automatic Releases action
Determining release tags
Retrieving commit history
Generating changelog
Generating release tag
  Attempting to create or update release tag "beta"
  Could not create new tag "refs/tags/beta" (Resource not accessible by integration) therefore updating existing tag "tags/beta"
  Error: Resource not accessible by integration
```

## Summary

(short description of what does this PR, Issue #, etc.)

## Checklist

- [ ] Classes, Variables, function and methods logic  ok
- [ ] Comments written explaining what the code does
- [ ] All python code is PEP8 compliant (run black .)
- [ ] No lint issues (run flake8)
- [ ] Test coverage with pytest implemented
- [ ] Reviewers assigned (at least 1 mentor)

## Manual test evidence

(attach command-line examples, execution output & logs, etc.)
