### PR TITLE
Downgrade M2Crypto dependency to version 0.40.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 httplib2>=0.12.0
 git+https://github.com/pysimplesoap/pysimplesoap.git@stable_py3k#pysimplesoap
-m2crypto>=0.18
+m2crypto==0.40.1
 fpdf>=1.7.2
 dbf>=0.88.019
 Pillow>=2.0.0


### PR DESCRIPTION
The lastest version of M2Crypto (0.41.0) was causing a dependency issue. After testing, it was determined that version 0.40.1 resolves the problem without introducing any new issues.

## Summary

(short description of what does this PR, Issue #, etc.)

## Checklist

- [ ] Classes, Variables, function and methods logic  ok
- [ ] Comments written explaining what the code does
- [ ] All python code is PEP8 compliant (run black .)
- [ ] No lint issues (run flake8)
- [ ] Test coverage with pytest implemented
- [ ] Reviewers assigned (at least 1 mentor)

## Manual test evidence

(attach command-line examples, execution output & logs, etc.)
