### PR TITLE
nsis: add missing file.close()

### DIFF
--- a/nsis.py
+++ b/nsis.py
@@ -304,6 +304,7 @@ class NSISScript(object):
                 ),
             }
         )
+        ofi.close()
 
     def compile(self, pathname="base.nsi"):
         os.startfile(pathname, "compile")


### PR DESCRIPTION
## Summary

Many changes to files in python do not go into effect until after the file is closed, so if your script edits, leaves open, and reads a file, it won't see the edits.

## Checklist

- [ ] Classes, Variables, function and methods logic  ok
- [ ] Comments written explaining what the code does
- [ ] All python code is PEP8 compliant (run black .)
- [ ] No lint issues (run flake8)
- [ ] Test coverage with pytest implemented
- [ ] Reviewers assigned (at least 1 mentor)

## Manual test evidence

(attach command-line examples, execution output & logs, etc.)
