### PR TITLE
nsis: add missing file.close()

### DIFF
--- a/nsis.py
+++ b/nsis.py
@@ -265,6 +265,7 @@ class NSISScript:
             'unregister_com_servers_dll': ''.join([unregister_com_server_dll % comserver for comserver in self.comserver_files_dll]),
             'unregister_com_servers_exe': ''.join([unregister_com_server_tlb % comserver for comserver in self.comserver_files_tlb]),
         })
+        ofi.close()
 
     def compile(self, pathname="base.nsi"):
         os.startfile(pathname, 'compile')


### PR DESCRIPTION
## Summary

Missing file.close() can cause errors when file is read before the garbage collector closes the file.

## Checklist

- [ ] Classes, Variables, function and methods logic  ok
- [ ] Comments written explaining what the code does
- [ ] All python code is PEP8 compliant (run black .)
- [ ] No lint issues (run flake8)
- [ ] Test coverage with pytest implemented
- [ ] Reviewers assigned (at least 1 mentor)

## Manual test evidence

(attach command-line examples, execution output & logs, etc.)
