### PR TITLE
Change HOMO flag to False in setup scripts and update imports in setu…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ except:
 
 __version__ = "%s.%s.%s" % (sys.version_info[0:2] + (rev,))
 
-HOMO = True
+HOMO = False    
 
 import setuptools
 

--- a/setup_win.py
+++ b/setup_win.py
@@ -21,7 +21,7 @@ import sys
 
 __version__ = "3.10.0000"
 
-HOMO = True
+HOMO = False
 
 # build a one-click-installer for windows:
 import py2exe
@@ -33,8 +33,8 @@ from pyafipws.nsis import build_installer, Target
 #import pyrece
 from pyafipws import wsaa
 from pyafipws import wsfev1, rece1, rg3685
-#import wsfexv1, recex1
-#import wsbfev1, receb1
+import wsfexv1, recex1
+import wsbfev1, receb1
 #import wsmtx, recem
 #import wsct, recet
 #import wsfecred
@@ -53,7 +53,7 @@ from pyafipws import wsfev1, rece1, rg3685
 #import wsremharina
 #import wsremazucar
 #import wscoc
-#import wscdc
+import wscdc
 #import cot
 #import iibb
 #import trazamed


### PR DESCRIPTION
This pull request includes changes to the `setup.py` and `setup_win.py` files, primarily to update configuration flags and import statements. The most significant updates involve disabling the `HOMO` flag and enabling additional imports in `setup_win.py`.

### Configuration Updates:
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L31-R31): The `HOMO` flag was changed from `True` to `False`, potentially altering the application's behavior or environment configuration.
* [`setup_win.py`](diffhunk://#diff-0e518e294aab9a3a38ea3e3383d720f1bf7b4d1ddf6e5849bedd88131a1a12acL24-R24): Similarly, the `HOMO` flag was changed from `True` to `False` in the Windows-specific setup script.

### Import Adjustments:
* [`setup_win.py`](diffhunk://#diff-0e518e294aab9a3a38ea3e3383d720f1bf7b4d1ddf6e5849bedd88131a1a12acL36-R37): Previously commented-out imports for `wsfexv1`, `recex1`, `wsbfev1`, and `receb1` were uncommented, making these modules active in the script.
* [`setup_win.py`](diffhunk://#diff-0e518e294aab9a3a38ea3e3383d720f1bf7b4d1ddf6e5849bedd88131a1a12acL56-R56): The `wscdc` module, which was previously commented out, is now imported, potentially expanding functionality.
