### PR TITLE
pyafipws: replace SafeConfigParser imports with utils

### DIFF
--- a/tests/test_pyemail.py
+++ b/tests/test_pyemail.py
@@ -24,7 +24,7 @@ from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 import sys, os
 import smtplib
-from configparser import SafeConfigParser
+from pyafipws.utils import SafeConfigParser
 
 pytestmark = [pytest.mark.dontusefix]
 

--- a/ws_sire.py
+++ b/ws_sire.py
@@ -40,7 +40,7 @@ from pyafipws.utils import (
     SoapFault,
     SimpleXMLElement,
 )
-from configparser import SafeConfigParser
+from pyafipws.utils import SafeConfigParser
 
 
 HOMO = False

--- a/ws_sr_padron.py
+++ b/ws_sr_padron.py
@@ -44,7 +44,7 @@ from pyafipws.utils import (
     SoapFault,
     safe_console,
 )
-from configparser import SafeConfigParser
+from pyafipws.utils import SafeConfigParser
 from pyafipws.padron import TIPO_CLAVE, PROVINCIAS
 
 

--- a/wscdc.py
+++ b/wscdc.py
@@ -28,7 +28,7 @@ __license__ = "LGPL-3.0-or-later"
 __version__ = "3.03a"
 
 import sys, os, time
-from configparser import SafeConfigParser
+from pyafipws.utils import SafeConfigParser
 from pyafipws.utils import inicializar_y_capturar_excepciones, BaseWS, get_install_dir
 from pyafipws.utils import leer, escribir, leer_dbf, guardar_dbf, N, A, I, json
 

--- a/wscpe_cli.py
+++ b/wscpe_cli.py
@@ -303,7 +303,7 @@ if __name__ == '__main__':
                 comienzo += longitud
         sys.exit(0)
 
-    from ConfigParser import SafeConfigParser
+    from pyafipws.utils import SafeConfigParser
 
     try:
     

--- a/wsctg.py
+++ b/wsctg.py
@@ -1051,7 +1051,7 @@ def main():
         sys.exit(0)
 
     import csv
-    from configparser import SafeConfigParser
+    from pyafipws.utils import SafeConfigParser
 
     try:
 

--- a/wsfecred.py
+++ b/wsfecred.py
@@ -1151,7 +1151,7 @@ def main():
         win32com.server.register.UseCommandLine(WSFECred)
         sys.exit(0)
 
-    from configparser import SafeConfigParser
+    from pyafipws.utils import SafeConfigParser
 
     try:
 

--- a/wslpg.py
+++ b/wslpg.py
@@ -3946,7 +3946,7 @@ def main():
         sys.exit(0)
 
     import csv
-    from configparser import SafeConfigParser
+    from pyafipws.utils import SafeConfigParser
 
     from pyafipws.wsaa import WSAA
 

--- a/wslsp.py
+++ b/wslsp.py
@@ -1075,7 +1075,7 @@ def main():
         sys.exit(0)
 
     import csv
-    from configparser import SafeConfigParser
+    from pyafipws.utils import SafeConfigParser
 
     from pyafipws.wsaa import WSAA
 

--- a/wsltv.py
+++ b/wsltv.py
@@ -886,7 +886,7 @@ def main():
         sys.exit(0)
 
     import csv
-    from configparser import SafeConfigParser
+    from pyafipws.utils import SafeConfigParser
 
     from pyafipws.wsaa import WSAA
 

--- a/wslum.py
+++ b/wslum.py
@@ -821,7 +821,7 @@ def main():
         sys.exit(0)
 
     import csv
-    from configparser import SafeConfigParser
+    from pyafipws.utils import SafeConfigParser
 
     from pyafipws.wsaa import WSAA
 

--- a/wsremazucar.py
+++ b/wsremazucar.py
@@ -756,7 +756,7 @@ def main():
         win32com.server.register.UseCommandLine(WSRemAzucar)
         sys.exit(0)
 
-    from configparser import SafeConfigParser
+    from pyafipws.utils import SafeConfigParser
 
     try:
 

--- a/wsremcarne.py
+++ b/wsremcarne.py
@@ -658,7 +658,7 @@ def main():
         win32com.server.register.UseCommandLine(WSRemCarne)
         sys.exit(0)
 
-    from configparser import SafeConfigParser
+    from pyafipws.utils import SafeConfigParser
 
     try:
 

--- a/wsremharina.py
+++ b/wsremharina.py
@@ -825,7 +825,7 @@ def main():
         win32com.server.register.UseCommandLine(WSRemHarina)
         sys.exit(0)
 
-    from configparser import SafeConfigParser
+    from pyafipws.utils import SafeConfigParser
 
     try:
 


### PR DESCRIPTION
Python 3.13 compatibility.

SafeConfigParser was removed from configparser in Python 3.12+. The utils.py already has a working shim (lines 56-65) that maps ConfigParser -> SafeConfigParser on Python 3. All direct imports from configparser/ConfigParser were replaced with the shim export.

## Summary

(short description of what does this PR, Issue #, etc.)

## Checklist

- [ ] Classes, Variables, function and methods logic  ok
- [ ] Comments written explaining what the code does
- [ ] All python code is PEP8 compliant (run black .)
- [ ] No lint issues (run flake8)
- [ ] Test coverage with pytest implemented
- [ ] Reviewers assigned (at least 1 mentor)

## Manual test evidence

(attach command-line examples, execution output & logs, etc.)
