### PR TITLE
fix: restore Python 3.12+ compatibility (configparser.SafeConfigParser was removed)

### DIFF
--- a/pyemail.py
+++ b/pyemail.py
@@ -34,7 +34,7 @@ from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 import sys, os
 import smtplib
-from configparser import SafeConfigParser
+from configparser import ConfigParser as SafeConfigParser
 
 
 DEBUG = False

--- a/tests/test_pyemail.py
+++ b/tests/test_pyemail.py
@@ -24,7 +24,7 @@ from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 import sys, os
 import smtplib
-from configparser import SafeConfigParser
+from configparser import ConfigParser as SafeConfigParser
 
 pytestmark = [pytest.mark.dontusefix]
 

--- a/ws_sire.py
+++ b/ws_sire.py
@@ -40,7 +40,7 @@ from pyafipws.utils import (
     SoapFault,
     SimpleXMLElement,
 )
-from configparser import SafeConfigParser
+from configparser import ConfigParser as SafeConfigParser
 
 
 HOMO = False

--- a/ws_sr_padron.py
+++ b/ws_sr_padron.py
@@ -44,7 +44,7 @@ from pyafipws.utils import (
     SoapFault,
     safe_console,
 )
-from configparser import SafeConfigParser
+from configparser import ConfigParser as SafeConfigParser
 from pyafipws.padron import TIPO_CLAVE, PROVINCIAS
 
 

--- a/wscdc.py
+++ b/wscdc.py
@@ -28,7 +28,7 @@ __license__ = "LGPL-3.0-or-later"
 __version__ = "3.03a"
 
 import sys, os, time
-from configparser import SafeConfigParser
+from configparser import ConfigParser as SafeConfigParser
 from pyafipws.utils import inicializar_y_capturar_excepciones, BaseWS, get_install_dir
 from pyafipws.utils import leer, escribir, leer_dbf, guardar_dbf, N, A, I, json
 

--- a/wscpe_cli.py
+++ b/wscpe_cli.py
@@ -303,7 +303,7 @@ if __name__ == '__main__':
                 comienzo += longitud
         sys.exit(0)
 
-    from ConfigParser import SafeConfigParser
+    from configparser import ConfigParser as SafeConfigParser
 
     try:
     

--- a/wsctg.py
+++ b/wsctg.py
@@ -1051,7 +1051,7 @@ def main():
         sys.exit(0)
 
     import csv
-    from configparser import SafeConfigParser
+    from configparser import ConfigParser as SafeConfigParser
 
     try:
 

--- a/wsfecred.py
+++ b/wsfecred.py
@@ -1151,7 +1151,7 @@ def main():
         win32com.server.register.UseCommandLine(WSFECred)
         sys.exit(0)
 
-    from configparser import SafeConfigParser
+    from configparser import ConfigParser as SafeConfigParser
 
     try:
 

--- a/wslpg.py
+++ b/wslpg.py
@@ -3946,7 +3946,7 @@ def main():
         sys.exit(0)
 
     import csv
-    from configparser import SafeConfigParser
+    from configparser import ConfigParser as SafeConfigParser
 
     from pyafipws.wsaa import WSAA
 

--- a/wslsp.py
+++ b/wslsp.py
@@ -1075,7 +1075,7 @@ def main():
         sys.exit(0)
 
     import csv
-    from configparser import SafeConfigParser
+    from configparser import ConfigParser as SafeConfigParser
 
     from pyafipws.wsaa import WSAA
 

--- a/wsltv.py
+++ b/wsltv.py
@@ -886,7 +886,7 @@ def main():
         sys.exit(0)
 
     import csv
-    from configparser import SafeConfigParser
+    from configparser import ConfigParser as SafeConfigParser
 
     from pyafipws.wsaa import WSAA
 

--- a/wslum.py
+++ b/wslum.py
@@ -821,7 +821,7 @@ def main():
         sys.exit(0)
 
     import csv
-    from configparser import SafeConfigParser
+    from configparser import ConfigParser as SafeConfigParser
 
     from pyafipws.wsaa import WSAA
 

--- a/wsremazucar.py
+++ b/wsremazucar.py
@@ -756,7 +756,7 @@ def main():
         win32com.server.register.UseCommandLine(WSRemAzucar)
         sys.exit(0)
 
-    from configparser import SafeConfigParser
+    from configparser import ConfigParser as SafeConfigParser
 
     try:
 

--- a/wsremcarne.py
+++ b/wsremcarne.py
@@ -658,7 +658,7 @@ def main():
         win32com.server.register.UseCommandLine(WSRemCarne)
         sys.exit(0)
 
-    from configparser import SafeConfigParser
+    from configparser import ConfigParser as SafeConfigParser
 
     try:
 

--- a/wsremharina.py
+++ b/wsremharina.py
@@ -825,7 +825,7 @@ def main():
         win32com.server.register.UseCommandLine(WSRemHarina)
         sys.exit(0)
 
-    from configparser import SafeConfigParser
+    from configparser import ConfigParser as SafeConfigParser
 
     try:
 


### PR DESCRIPTION
## Problem

`configparser.SafeConfigParser` was deprecated since Python 3.2 and **removed in Python 3.12** ([gh-89336](https://github.com/python/cpython/issues/89336)). 15 modules in this repo still do the bare import, so they raise `ImportError` at import time on any Python >= 3.12:

```
$ python3.12 -c "from pyafipws.ws_sr_padron import WSSrPadronA5"
ImportError: cannot import name 'SafeConfigParser' from 'configparser'
```

Affected modules include `ws_sr_padron`, `wscdc`, `wsctg`, `wslpg`, `wslsp`, `wsltv`, `wslum`, `wsfecred`, `ws_sire`, `wscpe_cli`, `wsremazucar`, `wsremcarne`, `wsremharina`, `pyemail` and `tests/test_pyemail.py`.

This matters in practice for anyone running the library inside a modern container image — we hit it on Python 3.12.3 (Debian 12 / `odoo:19.0`), where `wsaa` and `wsfev1` import fine but `ws_sr_padron` does not.

## Fix

Use the same one-line alias that `utils.py` already uses in its py3 fallback branch:

```python
from configparser import ConfigParser as SafeConfigParser
```

`ConfigParser` has been the implementation behind the `SafeConfigParser` name since Python 3.2, so behaviour is unchanged on every version that currently works.

`utils.py` is intentionally **not** touched — it already has the correct `try: from ConfigParser import SafeConfigParser / except ImportError: from configparser import ConfigParser as SafeConfigParser` guard.

## Scope

- 15 files, 15 insertions, 15 deletions — all the same one-line change.
- No functional change, no new dependency, no version bump.
- Branched from `d595b07` (current `main`).

Verified after the change:

```
$ python3 -c "from pyafipws.ws_sr_padron import WSSrPadronA5; w = WSSrPadronA5(); print('ok', w.Version)"
ok 3.05a
$ python3 -c "import pyafipws.wsaa, pyafipws.wsfev1; print('ok')"
ok
```

and no bare imports left outside `utils.py`:

```
$ grep -rn '^\s*from [Cc]onfig[Pp]arser import SafeConfigParser$' --include='*.py' . | grep -v '^./utils.py:'
(no output)
```